### PR TITLE
feat(restclient): improve retry function to accept optional retries count

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export type ApiConfig = {
   appId: string;
+  retries?: number;
 };
 
 export interface ApiResponse {

--- a/src/utils/constants/constants.spec.ts
+++ b/src/utils/constants/constants.spec.ts
@@ -28,7 +28,7 @@ describe("Constants", () => {
 
   it("should have correct constants", () => {
     expect(Constants.API_RETRIE_DELAY).toEqual(1000);
-    expect(Constants.API_RETRIES).toEqual(2);
+    expect(Constants.API_RETRIES).toEqual(1);
     expect(Constants.API_BASE_URL).toEqual("https://api.woovi.com");
     expect(Constants.WH_ALGORITHM).toEqual("sha256");
     expect(Constants.WH_SIGNATURE_FORMAT).toEqual("base64");

--- a/src/utils/constants/index.ts
+++ b/src/utils/constants/index.ts
@@ -1,7 +1,7 @@
 import type { BinaryToTextEncoding } from "crypto";
 
 export const API_BASE_URL = "https://api.woovi.com" as const;
-export const API_RETRIES = 2 as const;
+export const API_RETRIES = 1 as const;
 export const API_RETRIE_DELAY = 1000 as const;
 
 export const SDK_VERSION: string = "1.0.0";

--- a/src/utils/restClient/index.ts
+++ b/src/utils/restClient/index.ts
@@ -96,7 +96,7 @@ const RestClient = (clientConfig: ApiConfig) => {
       throw await response.json();
     };
 
-    return await retryWithExponentialBackoff(fetchFn, retries);
+    return await retryWithExponentialBackoff(fetchFn, clientConfig.retries || retries);
   }
 
   return fetcher;


### PR DESCRIPTION
This pull brings a customized option for how many retries the API can make in case of an error, the default is 1