### PR TITLE
fix(webhook): webhook handler typings

### DIFF
--- a/src/clients/webhook/handler/index.ts
+++ b/src/clients/webhook/handler/index.ts
@@ -1,13 +1,12 @@
-import crypto from "node:crypto";
-import constants from "@utils/constants";
+import crypto from 'node:crypto';
+import constants from '@utils/constants';
 import type {
   HandlerFn,
   VerifyPayloadType,
   WebhookPayload,
   WebhookRegistrationConfig,
   WebhooksHandler,
-  WebhooksHandlerMap,
-} from "./types";
+} from './types';
 
 export default (config: WebhookRegistrationConfig): WebhooksHandler => {
   return {
@@ -17,8 +16,8 @@ export default (config: WebhookRegistrationConfig): WebhooksHandler => {
 };
 
 export const verifyPayload = ({ payload, signature }: VerifyPayloadType) => {
-  const publicKey = Buffer.from(constants.WH_PUBLIC_KEY, "base64").toString(
-    "ascii",
+  const publicKey = Buffer.from(constants.WH_PUBLIC_KEY, 'base64').toString(
+    'ascii',
   );
 
   const verify = crypto.createVerify(constants.WH_ALGORITHM);
@@ -39,10 +38,10 @@ export async function handleWebhooks(
   config: WebhookRegistrationConfig,
   req: Request,
 ): Promise<Response> {
-  const webhook_signature = req.headers.get("x-webhook-signature");
+  const webhook_signature = req.headers.get('x-webhook-signature');
 
   if (!webhook_signature) {
-    return new Response("Error occurred -- no x-webhook-signature header", {
+    return new Response('Error occurred -- no x-webhook-signature header', {
       status: 400,
     });
   }
@@ -56,23 +55,23 @@ export async function handleWebhooks(
       signature: webhook_signature,
     })
   )
-    return new Response("Error occurred -- invalid signature", {
+    return new Response('Error occurred -- invalid signature', {
       status: 400,
     });
 
-  if ((payload as any)?.evento === "teste_webhook") {
-    return new Response("Test webhook acknowledged", { status: 200 });
+  if ((payload as any)?.evento === 'teste_webhook') {
+    return new Response('Test webhook acknowledged', { status: 200 });
   }
 
-  const handlerMap: WebhooksHandlerMap = {
-    "OPENPIX:CHARGE_CREATED": config.onChargeCreated,
-    "OPENPIX:CHARGE_COMPLETED": config.onChargeCompleted,
-    "OPENPIX:CHARGE_EXPIRED": config.onChargeExpired,
-    "OPENPIX:TRANSACTION_RECEIVED": config.onTransactionReceived,
-    "OPENPIX:TRANSACTION_REFUND_RECEIVED": config.onTransactionRefundReceived,
-    "OPENPIX:MOVEMENT_CONFIRMED": config.onMovementConfirmed,
-    "OPENPIX:MOVEMENT_FAILED": config.onMovementFailed,
-    "OPENPIX:MOVEMENT_REMOVED": config.onMovementRemoved,
+  const handlerMap = {
+    'OPENPIX:CHARGE_CREATED': config.onChargeCreated,
+    'OPENPIX:CHARGE_COMPLETED': config.onChargeCompleted,
+    'OPENPIX:CHARGE_EXPIRED': config.onChargeExpired,
+    'OPENPIX:TRANSACTION_RECEIVED': config.onTransactionReceived,
+    'OPENPIX:TRANSACTION_REFUND_RECEIVED': config.onTransactionRefundReceived,
+    'OPENPIX:MOVEMENT_CONFIRMED': config.onMovementConfirmed,
+    'OPENPIX:MOVEMENT_FAILED': config.onMovementFailed,
+    'OPENPIX:MOVEMENT_REMOVED': config.onMovementRemoved,
   };
 
   if (handlerMap[payload.event]) {
@@ -82,7 +81,7 @@ export async function handleWebhooks(
     );
   }
 
-  return new Response("", { status: 404 });
+  return new Response('', { status: 404 });
 }
 
 async function _handler(
@@ -92,5 +91,5 @@ async function _handler(
   const response = await callback(event);
   if (response) return response;
 
-  return new Response("", { status: 200 });
+  return new Response('', { status: 200 });
 }

--- a/src/clients/webhook/handler/types.ts
+++ b/src/clients/webhook/handler/types.ts
@@ -1,5 +1,5 @@
-import type { BasicCustomer } from "@src/clients/commonTypes";
-import type { Charge } from "@src/clients/transactions/commonTypes";
+import type { BasicCustomer } from '@src/clients/commonTypes';
+import type { Charge } from '@src/clients/transactions/commonTypes';
 
 export type WebhooksHandler = {
   config: WebhookRegistrationConfig;
@@ -39,6 +39,20 @@ type Pix = {
   raw: Raw;
 };
 
+type Payment = {
+  status: string;
+  value: number;
+  destinationAlias: string;
+  correlationID: string;
+};
+
+type Transaction = {
+  correlationID: string;
+  value: number;
+  endToEndId: string;
+  time: string;
+};
+
 type ChargePayload = {
   charge: ChargePayload;
   pix: Pix;
@@ -50,36 +64,45 @@ type TransactionPayload = {
   pix: Pix;
 };
 
-type MoventPayload = {
+type MovementPayload = {
   charge?: ChargePayload;
-  pix: Pix;
+  pix?: Pix;
+  payment?: Payment;
+  transaction?: Transaction;
 };
 
+type ChargeCreatedPayload = { event: 'OPENPIX:CHARGE_CREATED' } & ChargePayload;
+type ChargeCompletedPayload = {
+  event: 'OPENPIX:CHARGE_COMPLETED';
+} & ChargePayload;
+type ChargeExpiredPayload = { event: 'OPENPIX:CHARGE_EXPIRED' } & ChargePayload;
+
+type TransactionReceivedPayload = {
+  event: 'OPENPIX:TRANSACTION_RECEIVED';
+} & TransactionPayload;
+type TransactionRefundReceivedPayload = {
+  event: 'OPENPIX:TRANSACTION_REFUND_RECEIVED';
+} & TransactionPayload;
+
+type MovementConfirmedPayload = {
+  event: 'OPENPIX:MOVEMENT_CONFIRMED';
+} & MovementPayload;
+type MovementFailedPayload = {
+  event: 'OPENPIX:MOVEMENT_FAILED';
+} & MovementPayload;
+type MovementRemovedPayload = {
+  event: 'OPENPIX:MOVEMENT_REMOVED';
+} & MovementPayload;
+
 export type WebhookPayload =
-  | ({
-      event: "OPENPIX:CHARGE_CREATED";
-    } & ChargePayload)
-  | ({
-      event: "OPENPIX:CHARGE_COMPLETED";
-    } & ChargePayload)
-  | ({
-      event: "OPENPIX:CHARGE_EXPIRED";
-    } & ChargePayload)
-  | ({
-      event: "OPENPIX:TRANSACTION_RECEIVED";
-    } & TransactionPayload)
-  | ({
-      event: "OPENPIX:TRANSACTION_REFUND_RECEIVED";
-    } & TransactionPayload)
-  | ({
-      event: "OPENPIX:MOVEMENT_CONFIRMED";
-    } & MoventPayload)
-  | ({
-      event: "OPENPIX:MOVEMENT_FAILED";
-    } & MoventPayload)
-  | ({
-      event: "OPENPIX:MOVEMENT_REMOVED";
-    } & MoventPayload);
+  | ChargeCreatedPayload
+  | ChargeCompletedPayload
+  | ChargeExpiredPayload
+  | TransactionReceivedPayload
+  | TransactionRefundReceivedPayload
+  | MovementConfirmedPayload
+  | MovementFailedPayload
+  | MovementRemovedPayload;
 
 export type HandlerFn<T> = (
   payload: T,
@@ -90,17 +113,13 @@ export type VerifyPayloadType = {
   signature: string;
 };
 
-export type WebhooksHandlerMap = {
-  [path: string]: HandlerFn<WebhookPayload> | undefined;
-};
-
 export type WebhookRegistrationConfig = {
-  onChargeCreated?: HandlerFn<WebhookPayload>;
-  onChargeCompleted?: HandlerFn<WebhookPayload>;
-  onChargeExpired?: HandlerFn<WebhookPayload>;
-  onTransactionReceived?: HandlerFn<WebhookPayload>;
-  onTransactionRefundReceived?: HandlerFn<WebhookPayload>;
-  onMovementConfirmed?: HandlerFn<WebhookPayload>;
-  onMovementFailed?: HandlerFn<WebhookPayload>;
-  onMovementRemoved?: HandlerFn<WebhookPayload>;
+  onChargeCreated?: HandlerFn<ChargeCreatedPayload>;
+  onChargeCompleted?: HandlerFn<ChargeCompletedPayload>;
+  onChargeExpired?: HandlerFn<ChargeExpiredPayload>;
+  onTransactionReceived?: HandlerFn<TransactionReceivedPayload>;
+  onTransactionRefundReceived?: HandlerFn<TransactionRefundReceivedPayload>;
+  onMovementConfirmed?: HandlerFn<MovementConfirmedPayload>;
+  onMovementFailed?: HandlerFn<MovementFailedPayload>;
+  onMovementRemoved?: HandlerFn<MovementRemovedPayload>;
 };


### PR DESCRIPTION
- Update the parameter types of webhook handlers to respect the payloads according to the event type

Before changes (the event is a union and `payment` and `transaction` are missing):
![image](https://github.com/user-attachments/assets/14a3a8bb-2c62-4a1b-9203-f6d41d289302)
![image](https://github.com/user-attachments/assets/d3059971-5249-42cb-86d8-0c499e9d4312)

After changes:
![image](https://github.com/user-attachments/assets/7b4e2dc6-0fb4-4246-963c-20155faf3760)

- Add `transaction` and `payment` in pix out events (movements).