### PR TITLE
fix(account): update account types and endpoint for account retrieval

### DIFF
--- a/src/clients/account/commonTypes.ts
+++ b/src/clients/account/commonTypes.ts
@@ -6,4 +6,9 @@ export type Account = {
     blocked: number;
     available: number;
   };
+  taxId: string;
+  officialName: string;
+  tradeName: string;
+  branch: string;
+  account: string
 };

--- a/src/clients/account/get/index.ts
+++ b/src/clients/account/get/index.ts
@@ -3,5 +3,5 @@ import type { GetPayload, GetResponse } from "./types";
 
 export default (restClient: RestClientApi) => {
   return (data: GetPayload) =>
-    restClient<GetResponse>(`/api/v1/charge/${data.id}`);
+    restClient<GetResponse>(`/api/v1/account/${data.id}`);
 };


### PR DESCRIPTION
This pull request introduces updates to the `Account` type definition and modifies the API endpoint used in the `get` client function. These changes enhance the structure of account-related data and ensure the client function aligns with the updated API specification.

Updates to account data structure:

* [`src/clients/account/commonTypes.ts`](diffhunk://#diff-71e47f6c66961c7d0bfff20e64da8acb6196acc4cb6589f985d3d07b0296c527R9-R13): Added new fields to the `Account` type, including `taxId`, `officialName`, `tradeName`, `branch`, and `account`, to provide a more comprehensive representation of account details.

API endpoint update:

* [`src/clients/account/get/index.ts`](diffhunk://#diff-953e4e6ed85d00d009f03e9ed4f52a25755ef1422bd25fa97fcfbb561507cd2fL6-R6): Changed the API endpoint from `/api/v1/charge/${data.id}` to `/api/v1/account/${data.id}` in the `get` client function to reflect the updated API design.

Solve issue #80 