### PR TITLE
Update build script and enhance exports configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   },
   "license": "MIT",
   "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
   "pre-commit": {
     "run": "lint"
   },
@@ -33,9 +35,9 @@
   },
   "repository": "git@github.com:woovibr/woovi-nodejs-sdk.git",
   "scripts": {
-    "build": "tsc --project tsconfig.json && tscpaths -p tsconfig.json -s ./src -o ./dist",
+    "build": "rslib build",
     "commit": "cz",
-    "format": "biome check ./src --apply",
+    "format": "biome check ./src --write",
     "lint": "biome lint ./src",
     "prepare": "pnpm build",
     "prepublishOnly": "pnpm build",
@@ -45,5 +47,14 @@
     "release:minor": "npm version minor && git push --follow-tags",
     "release:patch": "npm version patch && git push --follow-tags"
   },
-  "types": "./dist/index.d.ts"
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ]
 }


### PR DESCRIPTION
Refactor the build script for improved efficiency and update the exports configuration to support module and type definitions.

Before the changes:
´´´
npm notice name: @woovi/node-sdk
npm notice version: 1.2.7
npm notice filename: woovi-node-sdk-1.2.7.tgz
npm notice package size: 51.6 kB
npm notice unpacked size: 243.9 kB
npm notice shasum: 9b1c450b947c8d46d32d74414ecbdeaf7614033c
npm notice integrity: sha512-2uhbzv2k2X6ep[...]izxvXJEbQN+Qg==
npm notice total files: 336
npm notice
woovi-node-sdk-1.2.7.tgz
´´´

after the changes:
´´´
npm notice name: @woovi/node-sdk
npm notice version: 1.2.7
npm notice filename: woovi-node-sdk-1.2.7.tgz
npm notice package size: 15.2 kB
npm notice unpacked size: 88.1 kB
npm notice shasum: 1e62d4bf0d6f41853732825a79fb72418e50ccd8
npm notice integrity: sha512-gRO/X5W9G0o3g[...]NnnC7Af7fJyLA==
npm notice total files: 165
npm notice
woovi-node-sdk-1.2.7.tgz
´´´