### PR TITLE
feat: implemented charge batch retrieval through buffered or streamedresponse + fixed tests for different OSes

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,3 @@
-/**
- * For a detailed explanation regarding each configuration property, visit:
- * https://jestjs.io/docs/configuration
- */
-
-/** @type {import('jest').Config} */
 const config = {
   collectCoverage: true,
   coverageDirectory: "coverage",
@@ -12,10 +6,10 @@ const config = {
     "^.+\\.(t|j)sx?$": "@swc/jest",
   },
   moduleNameMapper: {
-		"^@src/(.*)$": "<rootDir>/src/$1",
-		"^@utils/(.*)$": "<rootDir>/src/utils/$1",
-		
-	},
+    "^@src/(.*)$": "<rootDir>/src/$1",
+    "^@utils/(.*)$": "<rootDir>/src/utils/$1",
+  },
+  testPathIgnorePatterns: ["/node_modules/", "/dist/"],
 };
 
 module.exports = config;

--- a/src/clients/charge/get/get.spec.ts
+++ b/src/clients/charge/get/get.spec.ts
@@ -89,3 +89,173 @@ test("Should have success", async () => {
     charge,
   });
 });
+
+test("Should have success for charge batch by id (buffer mode)", async () => {
+  const charges = [
+    {
+      status: "ACTIVE",
+      customer: {
+        name: "Dan",
+        email: "email0@example.com",
+        phone: "5511999999999",
+        taxID: {
+          taxID: "31324227036",
+          type: "BR:CPF",
+        },
+      },
+      value: 100,
+      comment: "good",
+      correlationID: "9134e286-6f71-427a-bf00-241681624586",
+      paymentLinkID: "7777-6f71-427a-bf00-241681624586",
+      paymentLinkUrl:
+        "https://openpix.com.br/pay/9134e286-6f71-427a-bf00-241681624586",
+      globalID: "Q2hhcmdlOjcxOTFmMWIwMjA0NmJmNWY1M2RjZmEwYg==",
+      qrCodeImage:
+        "https://api.openpix.com.br/openpix/charge/brcode/image/9134e286-6f71-427a-bf00-241681624586.png",
+      brCode:
+        "000201010212261060014br.gov.bcb.pix2584https://api.openpix.com.br/openpix/testing?transactionID=867ba5173c734202ac659721306b38c952040000530398654040.015802BR5909LOCALHOST6009Sao Paulo62360532867ba5173c734202ac659721306b38c963044BCA",
+      additionalInfo: [
+        {
+          key: "Product",
+          value: "Pencil",
+        },
+        {
+          key: "Invoice",
+          value: "18476",
+        },
+        {
+          key: "Order",
+          value: "302",
+        },
+      ],
+      expiresIn: 2592000,
+      expiresDate: "2021-04-01T17:28:51.882Z",
+      createdAt: "2021-03-02T17:28:51.882Z",
+      updatedAt: "2021-03-02T17:28:51.882Z",
+    },
+    {
+      status: "PAID",
+      customer: {
+        name: "Jane",
+        email: "email1@example.com",
+        phone: "5511888888888",
+        taxID: {
+          taxID: "12345678901",
+          type: "BR:CPF",
+        },
+      },
+      value: 200,
+      comment: "great",
+      correlationID: "b234e286-6f71-427a-bf00-241681624587",
+      paymentLinkID: "8888-6f71-427a-bf00-241681624587",
+      paymentLinkUrl:
+        "https://openpix.com.br/pay/b234e286-6f71-427a-bf00-241681624587",
+      globalID: "Q2hhcmdlOjcxOTFmMWIwMjA0NmJmNWY1M2RjZmEwYg==",
+      qrCodeImage:
+        "https://api.openpix.com.br/openpix/charge/brcode/image/b234e286-6f71-427a-bf00-241681624587.png",
+      brCode:
+        "000201010212261060014br.gov.bcb.pix2584https://api.openpix.com.br/openpix/testing?transactionID=1234567890abcdef1234567890abcdef52040000530398654040.015802BR5909LOCALHOST6009Sao Paulo62360532867ba5173c734202ac659721306b38c963044BCA",
+      additionalInfo: [
+        {
+          key: "Product",
+          value: "Pen",
+        },
+        {
+          key: "Invoice",
+          value: "18477",
+        },
+        {
+          key: "Order",
+          value: "303",
+        },
+      ],
+      expiresIn: 2592000,
+      expiresDate: "2021-05-01T17:28:51.882Z",
+      createdAt: "2021-04-02T17:28:51.882Z",
+      updatedAt: "2021-04-02T17:28:51.882Z",
+    },
+  ];
+
+  // Mock fetch to return each charge in order
+  let call = 0;
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      json: () => Promise.resolve({ charge: charges[call++] }),
+      ok: true,
+      status: 200,
+    }),
+  );
+
+  const response = await resource({
+    id: [
+      "9134e286-6f71-427a-bf00-241681624586",
+      "b234e286-6f71-427a-bf00-241681624587",
+    ],
+
+  });
+
+  expect(response).toEqual({
+    charge: charges,
+  });
+});
+
+test("Should have success for charge batch by id (stream mode, 10 items, 200ms delay)", async () => {
+    const charges = Array.from({ length: 10 }).map((_, i) => ({
+      status: i % 2 === 0 ? "ACTIVE" : "PAID",
+      customer: {
+        name: `Customer${i}`,
+        email: `email${i}@example.com`,
+        phone: `55119999999${i}${i}`,
+        taxID: {
+          taxID: `3132422703${i}`,
+          type: "BR:CPF",
+        },
+      },
+      value: 100 + i,
+      comment: `comment${i}`,
+      correlationID: `${i}134e286-6f71-427a-bf00-24168162458${i}`,
+      paymentLinkID: `${7777 + i}-6f71-427a-bf00-24168162458${i}`,
+      paymentLinkUrl: `https://openpix.com.br/pay/${i}134e286-6f71-427a-bf00-24168162458${i}`,
+      globalID: `Q2hhcmdlOjcxOTFmMWIwMjA0NmJmNWY1M2RjZmEwYg==`,
+      qrCodeImage: `https://api.openpix.com.br/openpix/charge/brcode/image/${i}134e286-6f71-427a-bf00-24168162458${i}.png`,
+      brCode: `000201010212261060014br.gov.bcb.pix2584https://api.openpix.com.br/openpix/testing?transactionID=${i}67ba5173c734202ac659721306b38c952040000530398654040.015802BR5909LOCALHOST6009Sao Paulo62360532867ba5173c734202ac659721306b38c963044BCA`,
+      additionalInfo: [
+        { key: "Product", value: `Product${i}` },
+        { key: "Invoice", value: `1847${i}` },
+        { key: "Order", value: `30${i}` },
+      ],
+      expiresIn: 2592000,
+      expiresDate: `2021-0${i + 1}-01T17:28:51.882Z`,
+      createdAt: `2021-0${i + 1}-02T17:28:51.882Z`,
+      updatedAt: `2021-0${i + 1}-02T17:28:51.882Z`,
+    }));
+
+    let call = 0;
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve({ charge: charges[call++] }),
+        ok: true,
+        status: 200,
+      }),
+    );
+
+    // Simulate stream mode: resource returns an async generator
+    // We'll assume resource({ id: [...], stream: true, delay: 200 }) yields each charge with delay
+    const ids = charges.map((_, i) => `${i}134e286-6f71-427a-bf00-24168162458${i}`);
+    const start = Date.now();
+    const received: any[] = [];
+    
+    await resource({ 
+      id: ids, 
+      mode: "stream", 
+      streamRoundDelayInMs: 200,
+      onData: (data) => {
+        received.push(data);
+      },
+    });
+
+    const elapsed = Date.now() - start;
+
+    expect(received).toEqual(charges);
+    expect(elapsed).toBeGreaterThanOrEqual(200 * (charges.length - 1));
+});

--- a/src/clients/charge/get/get.spec.ts
+++ b/src/clients/charge/get/get.spec.ts
@@ -248,7 +248,8 @@ test("Should have success for charge batch by id (stream mode, 10 items, 200ms d
     await resource({ 
       id: ids, 
       mode: "stream", 
-      streamRoundDelayInMs: 200,
+      chunkRoundDelayInMs: 200,
+      maxChunkSize: 5,
       onData: (data) => {
         received.push(data);
       },
@@ -257,5 +258,10 @@ test("Should have success for charge batch by id (stream mode, 10 items, 200ms d
     const elapsed = Date.now() - start;
 
     expect(received).toEqual(charges);
-    expect(elapsed).toBeGreaterThanOrEqual(200 * (charges.length - 1));
+
+    // Here it is okay to assume that the operation, with the provided data, will take less
+    // than 600ms to complete as we are simulating a delay of 200ms per chunk and want the
+    // tasks to complete in less than 100ms. In real scenarios, this might vary based on network
+    // and server conditions, but for testing purposes, we can set a performance threshold.
+    expect(elapsed).toBeLessThanOrEqual(600);
 });

--- a/src/clients/charge/get/index.ts
+++ b/src/clients/charge/get/index.ts
@@ -1,7 +1,30 @@
 import type { RestClientApi } from "@utils/types";
 import type { GetPayload, GetResponse } from "./types";
+import type { Charge } from "../commonTypes";
 
 export default (restClient: RestClientApi) => {
-  return (data: GetPayload) =>
-    restClient<GetResponse>(`/api/v1/charge/${data.id}`);
+  return async (data: GetPayload) => {
+    if (Array.isArray(data.id)) {
+      data.mode ??= "buffer";
+      data.streamRoundDelayInMs ??= 100;
+
+      const finalResult: Charge[] | null = data.mode === "buffer" ? [] : null;
+      for (const id of data.id) {
+        const response = await restClient<GetResponse>(`/api/v1/charge/${id}`);
+        if (data.mode === "stream" && data.onData) {
+          data.onData(response.charge as Charge);
+          await new Promise((resolve) => {
+            setTimeout(resolve, data.streamRoundDelayInMs);
+          });
+        } else {
+          finalResult!.push(response.charge as Charge);
+        }
+      }
+
+      return {
+        charge: finalResult,
+      };
+    }
+    return restClient<GetResponse>(`/api/v1/charge/${data.id}`);
+  };
 };

--- a/src/clients/charge/get/types.ts
+++ b/src/clients/charge/get/types.ts
@@ -1,9 +1,12 @@
 import type { Charge } from "../commonTypes";
 
 export type GetPayload = {
-  id: string;
+  id: string | string[];
+  mode?: "buffer" | "stream";
+  onData?: (data: Charge) => void;
+  streamRoundDelayInMs?: number;
 };
 
 export type GetResponse = {
-  charge: Charge;
+  charge: Charge | Charge[];
 };

--- a/src/clients/charge/get/types.ts
+++ b/src/clients/charge/get/types.ts
@@ -4,7 +4,8 @@ export type GetPayload = {
   id: string | string[];
   mode?: "buffer" | "stream";
   onData?: (data: Charge) => void;
-  streamRoundDelayInMs?: number;
+  chunkRoundDelayInMs?: number;
+  maxChunkSize?: number;
 };
 
 export type GetResponse = {

--- a/src/utils/constants/constants.spec.ts
+++ b/src/utils/constants/constants.spec.ts
@@ -41,7 +41,11 @@ describe("Constants", () => {
   });
 
   it("should return correct user agent", () => {
-    const expectedUserAgent = `Woovi Node.js SDK v1.0.0 (node ${process.version}-x64-linux)`;
-    expect(Constants.getUserAgent()).toEqual(expectedUserAgent);
+    const expectedUserAgents = [
+      `Woovi Node.js SDK v1.0.0 (node ${process.version}-x64-linux)`,
+      `Woovi Node.js SDK v1.0.0 (node ${process.version}-x64-win32)`,
+      `Woovi Node.js SDK v1.0.0 (node ${process.version}-x64-darwin)`,
+    ];
+    expect(expectedUserAgents).toContain(Constants.getUserAgent());
   });
 });


### PR DESCRIPTION
Notes:

Added feature to call `Charge` get with the following payload:
```ts
type GetPayload = {
  id: string | string[];
  mode?: "buffer" | "stream";
  onData?: (data: Charge) => void;
  streamRoundDelayInMs?: number;
}
```

When passing `string[]` to id instead of `string`, it allows you to start a batch charge request and use the fields `mode`, `onData` and `streamRoundDelayInMs`. The last two fields will work only in `stream` mode, where each entry can be processed independently when found. The tests cover basic behavior, not complex error ones.

> Ps: also fixed constants tests for different OSes such as Windows and MacOS in some cases, this is no the best implementation but works pretty well. Also the tests were not ignoring node_modules and dist, I added that for quality/performance/avoid repetition