### PR TITLE
improvement (create subscription): added frequency to create of subscriptions

### DIFF
--- a/src/clients/subscription/commonTypes.ts
+++ b/src/clients/subscription/commonTypes.ts
@@ -5,4 +5,6 @@ export interface Subscription {
   value: number;
   customer: Customer;
   dayGenerateCharge: number;
+  correlationID?: string;
+  status?: "ACTIVE" | "OVERDUE" | "COMPLETED" | "EXPIRED";
 }

--- a/src/clients/subscription/create/types.ts
+++ b/src/clients/subscription/create/types.ts
@@ -11,6 +11,7 @@ export type CreatePayload = {
   additionalInfo?: AdditionalInfo[];
   dayGenerateCharge: number;
   chargeType?: "DYNAMIC" | "OVERDUE";
+  frequency?: "WEEKLY" | "MONTHLY" | "BIMONTHLY" | "TRIMONTHLY" | "SEMIANNUALY" | "ANNUALY";
   dayDue?: number;
 };
 


### PR DESCRIPTION
This pull request introduces a small but important update to the `CreatePayload` type in `src/clients/subscription/create/types.ts`. The change adds a new optional property, `frequency`, which specifies the recurrence interval for charges. 

* [`src/clients/subscription/create/types.ts`](diffhunk://#diff-f70f6758a66692416765ddd6fde9850106a8361d7f9338ee476cf60a32fba5baR14): Added a `frequency` property to the `CreatePayload` type, allowing values like "WEEKLY", "MONTHLY", and other predefined intervals.