### PR TITLE
fix(fix customer request endpoint): correct customer GET endpoint from /refund to /customer

### DIFF
--- a/src/clients/customer/get/index.ts
+++ b/src/clients/customer/get/index.ts
@@ -3,5 +3,5 @@ import type { GetPayload, GetResponse } from "./types";
 
 export default (restClient: RestClientApi) => {
   return (data: GetPayload) =>
-    restClient<GetResponse>(`/api/v1/refund/${data.id}`);
+    restClient<GetResponse>(`/api/v1/customer/${data.id}`);
 };


### PR DESCRIPTION
The GET endpoint for retrieving customer detail was incorrectly pointing to /refund instead of /customer. This caused requests for customer information to fail or return incorrect data. This change updates the endpoint path to the correct /customer URL, ensuring that customer GET requests now return the expected results

Fix for the issue [96](https://github.com/woovibr/woovi-nodejs-sdk/issues/96).